### PR TITLE
Populate envp array on startup of UEFI application.

### DIFF
--- a/amd64/uefi/libc-full.M1
+++ b/amd64/uefi/libc-full.M1
@@ -29,7 +29,8 @@
 	push_rax                                       # Push it onto stack
 	mov_rax,[rip+DWORD] %GLOBAL__argv              # Get argv
 	push_rax                                       # Push it onto stack
-	push !0                                        # envp = NULL
+	mov_rax,[rip+DWORD] %GLOBAL__envp              # Get envp
+	push_rax                                       # Push it onto stack
 	call %FUNCTION_main
 
 :FUNCTION__exit

--- a/string.h
+++ b/string.h
@@ -41,10 +41,10 @@ size_t strcspn(char const* dest, char const* src);
 char* strpbrk(char const* dest, char const* breakset);
 
 /* Memory manipulation */
-void* memset(void* dest, int ch, size_t count );
-void* memcpy(void* dest, void const* src, size_t count );
-void* memmove(void* dest, void const* src, size_t count );
-int memcmp(void const* lhs, void const* rhs, size_t count );
-void* memchr( void const* ptr, int ch, size_t count );
+void* memset(void* dest, int ch, size_t count);
+void* memcpy(void* dest, void const* src, size_t count);
+void* memmove(void* dest, void const* src, size_t count);
+int memcmp(void const* lhs, void const* rhs, size_t count);
+void* memchr(void const* ptr, int ch, size_t count);
 #endif
 #endif


### PR DESCRIPTION
tested with kaem, it can now see env variables set by UEFI shell and can print e.g.

`echo ${var}`

if we set `var` in UEFI shell.