### PR TITLE
Fix UEFI calling convention.

### DIFF
--- a/amd64/amd64_defs.M1
+++ b/amd64/amd64_defs.M1
@@ -17,11 +17,11 @@
 
 DEFINE add_rax, 4805
 DEFINE add_rbp, 4881C5
-DEFINE add_rsp, 4881C4
 DEFINE add_rax,rbx 4801D8
 DEFINE add_rax,rbp 4801E8
 DEFINE add_rbx,rax 4801C3
 DEFINE and_rax,rbx 4821D8
+DEFINE and_rsp, 4881E4
 DEFINE call E8
 DEFINE call_rax FFD0
 DEFINE cmp_rbx,rax 4839C3
@@ -81,6 +81,7 @@ DEFINE mov_rax,[rsp+DWORD] 488B8424
 DEFINE mov_rax,[rip+DWORD] 488B05
 DEFINE mov_rbp,[rip+DWORD] 488B2D
 DEFINE mov_rsp,[rip+DWORD] 488B25
+DEFINE mov_rsp,[rsp+BYTE] 488BA424
 DEFINE mov_r8,[r8] 4D8B00
 DEFINE mov_r9,[r9] 4D8B09
 DEFINE mov_r10,[r10] 4D8B12
@@ -100,12 +101,24 @@ DEFINE or_rax,rbx 4809D8
 DEFINE pop_rax 58
 DEFINE pop_rbp 5D
 DEFINE pop_rbx 5B
+DEFINE pop_rsi 5E
 DEFINE pop_rdi 5F
+DEFINE pop_r12 415C
+DEFINE pop_r13 415D
+DEFINE pop_r14 415E
+DEFINE pop_r15 415F
 DEFINE push 6A
 DEFINE push_rax 50
 DEFINE push_rbp 55
 DEFINE push_rbx 53
 DEFINE push_rdi 57
+DEFINE push_rsi 56
+DEFINE push_rsp 54
+DEFINE push_r12 4154
+DEFINE push_r13 4155
+DEFINE push_r14 4156
+DEFINE push_r15 4157
+DEFINE push_[rsp] FF3424
 DEFINE ret C3
 DEFINE sal_rax, 48C1E0
 DEFINE shl_rax,cl 48D3E0

--- a/amd64/uefi/bootstrap.c
+++ b/amd64/uefi/bootstrap.c
@@ -221,9 +221,12 @@ char _read(FILE* f, unsigned size, FUNCTION read)
 	    "mov_r8,rsp"
 	    "lea_rax,[rbp+DWORD] %-24"
 	    "mov_rax,[rax]"
-	    "sub_rsp, %24"
+	    "push_rsp"
+	    "push_[rsp]"
+	    "and_rsp, %-16"
+	    "sub_rsp, %32"
 	    "call_rax"
-	    "add_rsp, %24"
+	    "mov_rsp,[rsp+BYTE] %40"
 	    "lea_rax,[rbp+DWORD] %-16"
 	    "mov_rax,[rax]"
 	    "test_rax,rax"
@@ -242,9 +245,12 @@ long _write(FILE* f, unsigned size, char c, FUNCTION write)
 	    "lea_r8,[rbp+DWORD] %-24"
 	    "lea_rax,[rbp+DWORD] %-32"
 	    "mov_rax,[rax]"
-	    "sub_rsp, %24"
+	    "push_rsp"
+	    "push_[rsp]"
+	    "and_rsp, %-16"
+	    "sub_rsp, %32"
 	    "call_rax"
-	    "add_rsp, %24");
+	    "mov_rsp,[rsp+BYTE] %40");
 }
 
 void _write_stdout(void* con_out, int c, FUNCTION output_string)
@@ -254,9 +260,12 @@ void _write_stdout(void* con_out, int c, FUNCTION output_string)
 	    "lea_rdx,[rbp+DWORD] %-16"
 	    "lea_rax,[rbp+DWORD] %-24"
 	    "mov_rax,[rax]"
-	    "sub_rsp, %16"
+	    "push_rsp"
+	    "push_[rsp]"
+	    "and_rsp, %-16"
+	    "sub_rsp, %32"
 	    "call_rax"
-	    "add_rsp, %16");
+	    "mov_rsp,[rsp+BYTE] %40");
 }
 
 void* _open_protocol(void* handle, struct efi_guid* protocol, void* agent_handle, void* controller_handle, long attributes, FUNCTION open_protocol)
@@ -267,6 +276,9 @@ void* _open_protocol(void* handle, struct efi_guid* protocol, void* agent_handle
 	    "mov_rdx,[rdx]"
 	    "push !0"
 	    "mov_r8,rsp"
+	    "push_rsp"
+	    "push_[rsp]"
+	    "and_rsp, %-16"
 	    "lea_r9,[rbp+DWORD] %-24"
 	    "mov_r9,[r9]"
 	    "lea_rax,[rbp+DWORD] %-40"
@@ -279,7 +291,7 @@ void* _open_protocol(void* handle, struct efi_guid* protocol, void* agent_handle
 	    "mov_rax,[rax]"
 	    "sub_rsp, %32"
 	    "call_rax"
-	    "add_rsp, %48"
+	    "mov_rsp,[rsp+BYTE] %56"
 	    "pop_rax");
 }
 
@@ -295,9 +307,12 @@ int _close_protocol(void *handle, struct efi_guid* protocol, void* agent_handle,
 	    "mov_r9,[r9]"
 	    "lea_rax,[rbp+DWORD] %-40"
 	    "mov_rax,[rax]"
+	    "push_rsp"
+	    "push_[rsp]"
+	    "and_rsp, %-16"
 	    "sub_rsp, %32"
 	    "call_rax"
-	    "add_rsp, %32");
+	    "mov_rsp,[rsp+BYTE] %40");
 }
 
 int _open_volume(struct efi_simple_file_system_protocol* rootfs, FUNCTION open_volume)
@@ -308,9 +323,12 @@ int _open_volume(struct efi_simple_file_system_protocol* rootfs, FUNCTION open_v
 	    "mov_rdx,rsp"
 	    "lea_rax,[rbp+DWORD] %-16"
 	    "mov_rax,[rax]"
-	    "sub_rsp, %16"
+	    "push_rsp"
+	    "push_[rsp]"
+	    "and_rsp, %-16"
+	    "sub_rsp, %32"
 	    "call_rax"
-	    "add_rsp, %16"
+	    "mov_rsp,[rsp+BYTE] %40"
 	    "pop_rax");
 }
 
@@ -324,6 +342,10 @@ FILE* _open(void* _rootdir, char* name, long mode, long attributes, FUNCTION ope
 	    "mov_r8,[r8]"
 	    "lea_r9,[rbp+DWORD] %-24"
 	    "mov_r9,[r9]"
+	    "push_rsp"
+	    "push_[rsp]"
+	    "and_rsp, %-16"
+	    "push_rax"
 	    "lea_rax,[rbp+DWORD] %-32"
 	    "mov_rax,[rax]"
 	    "push_rax"
@@ -331,7 +353,7 @@ FILE* _open(void* _rootdir, char* name, long mode, long attributes, FUNCTION ope
 	    "mov_rax,[rax]"
 	    "sub_rsp, %32"
 	    "call_rax"
-	    "add_rsp, %40"
+	    "mov_rsp,[rsp+BYTE] %56"
 	    "pop_rax");
 }
 
@@ -341,9 +363,12 @@ FILE* _close(FILE* f, FUNCTION close)
 	    "mov_rcx,[rcx]"
 	    "lea_rax,[rbp+DWORD] %-16"
 	    "mov_rax,[rax]"
-	    "sub_rsp, %8"
+	    "push_rsp"
+	    "push_[rsp]"
+	    "and_rsp, %-16"
+	    "sub_rsp, %32"
 	    "call_rax"
-	    "add_rsp, %8"
+	    "mov_rsp,[rsp+BYTE] %40"
 	);
 }
 
@@ -360,9 +385,12 @@ long _allocate_pages(unsigned type, unsigned memory_type, unsigned pages, long _
 	    "lea_r9,[rbp+DWORD] %-32"
 	    "lea_rax,[rbp+DWORD] %-40"
 	    "mov_rax,[rax]"
+	    "push_rsp"
+	    "push_[rsp]"
+	    "and_rsp, %-16"
 	    "sub_rsp, %32"
 	    "call_rax"
-	    "add_rsp, %32"
+	    "mov_rsp,[rsp+BYTE] %40"
 	    "lea_rax,[rbp+DWORD] %-32"
 	    "mov_rax,[rax]");
 }
@@ -376,9 +404,12 @@ void _free_pages(void* memory, unsigned pages, FUNCTION free_pages)
 	    "mov_rdx,[rdx]"
 	    "lea_rax,[rbp+DWORD] %-24"
 	    "mov_rax,[rax]"
-	    "sub_rsp, %16"
+	    "push_rsp"
+	    "push_[rsp]"
+	    "and_rsp, %-16"
+	    "sub_rsp, %32"
 	    "call_rax"
-	    "add_rsp, %16");
+	    "mov_rsp,[rsp+BYTE] %40");
 }
 
 int fgetc(FILE* f)

--- a/amd64/uefi/libc-core.M1
+++ b/amd64/uefi/libc-core.M1
@@ -15,7 +15,17 @@
 ## along with M2-Planet.  If not, see <http://www.gnu.org/licenses/>.
 
 :_start
+	# Save non-volatile registers
+	push_rbp
+	push_rbx
+	push_rdi
+	push_rsi
+	push_r12
+	push_r13
+	push_r14
+	push_r15
 	mov_rbp,rsp                                    # save stack pointer
+
 	mov_[rip+DWORD],rsp %__return_address          # save UEFI return address
 	mov_[rip+DWORD],rcx %GLOBAL__image_handle      # save image_handle
 	mov_[rip+DWORD],rdx %GLOBAL__system            # save system
@@ -41,6 +51,14 @@
 
 :FUNCTION___exit
 	mov_rsp,[rip+DWORD] %__return_address          # Get UEFI return address
+	pop_r15
+	pop_r14
+	pop_r13
+	pop_r12
+	pop_rsi
+	pop_rdi
+	pop_rbx
+	pop_rbp
 	ret
 
 # Switch to uefi stack

--- a/amd64/uefi/libc-full.M1
+++ b/amd64/uefi/libc-full.M1
@@ -15,7 +15,16 @@
 ## along with M2-Planet.  If not, see <http://www.gnu.org/licenses/>.
 
 :_start
+	push_rbp
+	push_rbx
+	push_rdi
+	push_rsi
+	push_r12
+	push_r13
+	push_r14
+	push_r15
 	mov_rbp,rsp                                    # save stack pointer
+
 	mov_[rip+DWORD],rsp %__return_address          # save UEFI return address
 	mov_[rip+DWORD],rcx %GLOBAL__image_handle      # save image_handle
 	mov_[rip+DWORD],rdx %GLOBAL__system            # save system
@@ -42,6 +51,14 @@
 
 :FUNCTION___exit
 	mov_rsp,[rip+DWORD] %__return_address          # Get UEFI return address
+	pop_r15
+	pop_r14
+	pop_r13
+	pop_r12
+	pop_rsi
+	pop_rdi
+	pop_rbx
+	pop_rbp
 	ret
 
 # Switch to uefi stack

--- a/uefi/uefi.c
+++ b/uefi/uefi.c
@@ -306,9 +306,12 @@ unsigned __uefi_1(void*, void*, FUNCTION f)
 	    "mov_rcx,[rcx]"
 	    "lea_rax,[rbp+DWORD] %-16"
 	    "mov_rax,[rax]"
-	    "sub_rsp, %8"
+	    "push_rsp"
+	    "push_[rsp]"
+	    "and_rsp, %-16"
+	    "sub_rsp, %32"
 	    "call_rax"
-	    "add_rsp, %8");
+	    "mov_rsp,[rsp+BYTE] %40");
 #else
 #error unsupported arch
 #endif
@@ -323,9 +326,12 @@ unsigned __uefi_2(void*, void*, FUNCTION f)
 	    "mov_rdx,[rdx]"
 	    "lea_rax,[rbp+DWORD] %-24"
 	    "mov_rax,[rax]"
-	    "sub_rsp, %16"
+	    "push_rsp"
+	    "push_[rsp]"
+	    "and_rsp, %-16"
+	    "sub_rsp, %32"
 	    "call_rax"
-	    "add_rsp, %16");
+	    "mov_rsp,[rsp+BYTE] %40");
 #else
 #error unsupported arch
 #endif
@@ -342,9 +348,12 @@ unsigned __uefi_3(void*, void*, void*, FUNCTION f)
 	    "mov_r8,[r8]"
 	    "lea_rax,[rbp+DWORD] %-32"
 	    "mov_rax,[rax]"
-	    "sub_rsp, %24"
+	    "push_rsp"
+	    "push_[rsp]"
+	    "and_rsp, %-16"
+	    "sub_rsp, %32"
 	    "call_rax"
-	    "add_rsp, %24");
+	    "mov_rsp,[rsp+BYTE] %40");
 #else
 #error unsupported arch
 #endif
@@ -363,9 +372,12 @@ unsigned __uefi_4(void*, void*, void*, void*, FUNCTION f)
 	    "mov_r9,[r9]"
 	    "lea_rax,[rbp+DWORD] %-40"
 	    "mov_rax,[rax]"
+	    "push_rsp"
+	    "push_[rsp]"
+	    "and_rsp, %-16"
 	    "sub_rsp, %32"
 	    "call_rax"
-	    "add_rsp, %32");
+	    "mov_rsp,[rsp+BYTE] %40");
 #else
 #error unsupported arch
 #endif
@@ -382,6 +394,10 @@ unsigned __uefi_5(void*, void*, void*, void*, void*, FUNCTION f)
 	    "mov_r8,[r8]"
 	    "lea_r9,[rbp+DWORD] %-32"
 	    "mov_r9,[r9]"
+	    "push_rsp"
+	    "push_[rsp]"
+	    "and_rsp, %-16"
+	    "push_rax"
 	    "lea_rax,[rbp+DWORD] %-40"
 	    "mov_rax,[rax]"
 	    "push_rax"
@@ -389,7 +405,7 @@ unsigned __uefi_5(void*, void*, void*, void*, void*, FUNCTION f)
 	    "mov_rax,[rax]"
 	    "sub_rsp, %32"
 	    "call_rax"
-	    "add_rsp, %40");
+	    "mov_rsp,[rsp+BYTE] %56");
 #else
 #error unsupported arch
 #endif
@@ -406,6 +422,9 @@ unsigned __uefi_6(void*, void*, void*, void*, void*, void*, FUNCTION f)
 	    "mov_r8,[r8]"
 	    "lea_r9,[rbp+DWORD] %-32"
 	    "mov_r9,[r9]"
+	    "push_rsp"
+	    "push_[rsp]"
+	    "and_rsp, %-16"
 	    "lea_rax,[rbp+DWORD] %-48"
 	    "mov_rax,[rax]"
 	    "push_rax"
@@ -416,7 +435,7 @@ unsigned __uefi_6(void*, void*, void*, void*, void*, void*, FUNCTION f)
 	    "mov_rax,[rax]"
 	    "sub_rsp, %32"
 	    "call_rax"
-	    "add_rsp, %48");
+	    "mov_rsp,[rsp+BYTE] %56");
 #else
 #error unsupported arch
 #endif


### PR DESCRIPTION
* Stack should be aligned to 16 bytes
* UEFI shadow stack space should be 32 bytes even for functions with less than 4 arguments
* Non-volatile registers must be restored before the program exist