### PR TITLE
Close open files when exiting.

### DIFF
--- a/amd64/linux/unistd.c
+++ b/amd64/linux/unistd.c
@@ -88,7 +88,7 @@ int execve(char* file_name, char** argv, char** envp)
 }
 
 int read(int fd, char* buf, unsigned count)
-{ /*maybe*/
+{
 	asm("lea_rdi,[rsp+DWORD] %24"
 	    "mov_rdi,[rdi]"
 	    "lea_rsi,[rsp+DWORD] %16"
@@ -100,7 +100,7 @@ int read(int fd, char* buf, unsigned count)
 }
 
 int write(int fd, char* buf, unsigned count)
-{/*maybe*/
+{
 	asm("lea_rdi,[rsp+DWORD] %24"
 	    "mov_rdi,[rdi]"
 	    "lea_rsi,[rsp+DWORD] %16"

--- a/stdio.c
+++ b/stdio.c
@@ -63,13 +63,14 @@ void __init_io()
 
 /* Flush all IO on exit */
 int fflush(FILE* stream);
+int fclose(FILE* stream);
 void __kill_io()
 {
 	fflush(stdout);
 	fflush(stderr);
 	while(NULL != __list)
 	{
-		fflush(__list);
+		fclose(__list);
 		__list = __list->next;
 	}
 }


### PR DESCRIPTION
Closing files is harmless on POSIX and is needed on UEFI in order not to leak open file descriptors.