### PR TITLE
Make variable getting to-spec

### DIFF
--- a/uefi/uefi.c
+++ b/uefi/uefi.c
@@ -636,7 +636,7 @@ size_t wcstombs(char* dest, char* src, size_t n);
 
 char* _get_environmental_variable(struct efi_guid* vendor_guid, char* name, unsigned size)
 {
-	unsigned data_size;
+	unsigned data_size = 0;
 	char* data;
 	char* variable_data;
 	char* envp_line = NULL;


### PR DESCRIPTION
It is expected by the UEFI specification that when a variable is retrieved with NULL data, the data length is 0. Previous behaviour in M2libc did not conform.

It appears some UEFI implementations depend on this and some do not (notably, EDK2 does not, but many bare metal platforms do).