### PR TITLE
Update symlink() syscall wrappers

### DIFF
--- a/aarch64/linux/unistd.c
+++ b/aarch64/linux/unistd.c
@@ -145,7 +145,7 @@ int unlink (char* filename)
 	    "SYSCALL");
 }
 
-int symlink(const char *path1, const char *path2)
+int symlink(char *path1, char *path2)
 {
 	asm("SET_X0_FROM_BP" "SUB_X0_16" "DEREF_X0"
 	    "SET_X2_FROM_X0"

--- a/amd64/linux/unistd.c
+++ b/amd64/linux/unistd.c
@@ -141,7 +141,7 @@ int unlink (char* filename)
 	    "syscall");
 }
 
-int symlink(const char *path1, const char *path2)
+int symlink(char *path1, char *path2)
 {
 	asm("lea_rdi,[rsp+DWORD] %16"
 	    "mov_rdi,[rdi]"

--- a/armv7l/linux/unistd.c
+++ b/armv7l/linux/unistd.c
@@ -135,7 +135,7 @@ int unlink (char* filename)
 	    "SYSCALL_ALWAYS");
 }
 
-int symlink(const char *path1, const char *path2)
+int symlink(char *path1, char *path2)
 {
 	asm("!4 R0 SUB R12 ARITH_ALWAYS"
 	    "!0 R0 LOAD32 R0 MEMORY"

--- a/knight/linux/unistd.c
+++ b/knight/linux/unistd.c
@@ -106,7 +106,7 @@ int unlink (char* filename)
 	    "SYS_UNLINK");
 }
 
-int symlink(const char *path1, const char *path2)
+int symlink(char *path1, char *path2)
 {
 	/* not implemented */
 	return(-1);

--- a/knight/native/unistd.c
+++ b/knight/native/unistd.c
@@ -120,7 +120,7 @@ int unlink (char* filename)
 	return 0;
 }
 
-int symlink(const char *path1, const char *path2)
+int symlink(char *path1, char *path2)
 {
 	/* Completely meaningless in bare metal */
 	return 0;

--- a/riscv32/linux/unistd.c
+++ b/riscv32/linux/unistd.c
@@ -183,7 +183,7 @@ int unlink (char* filename)
 }
 
 /* XXX: UNTESTED */
-int symlink(const char *path1, const char *path2)
+int symlink(char *path1, char *path2)
 {
 	asm("rd_a0 rs1_fp !-4 lw"
 	    "rd_a1 !-100 addi"  /* AT_FDCWD */

--- a/riscv64/linux/unistd.c
+++ b/riscv64/linux/unistd.c
@@ -127,7 +127,7 @@ int unlink (char* filename)
 }
 
 /* XXX: UNTESTED */
-int symlink(const char *path1, const char *path2)
+int symlink(char *path1, char *path2)
 {
 	asm("rd_a0 rs1_fp !-8 ld"
 	    "rd_a1 !-100 addi"  /* AT_FDCWD */

--- a/uefi/unistd.c
+++ b/uefi/unistd.c
@@ -296,7 +296,7 @@ int unlink(char* filename)
 	__uefi_1(fd, fd->delete);
 }
 
-int symlink(const char *path1, const char *path2)
+int symlink(char *path1, char *path2)
 {
 	/* This does not make sense in UEFI, where there are no symlinks */
 	return -1;

--- a/unistd.h
+++ b/unistd.h
@@ -54,7 +54,7 @@ int write(int fd, char* buf, unsigned count);
 int lseek(int fd, int offset, int whence);
 int close(int fd);
 int unlink (char *filename);
-int symlink(const char *path1, const char *path2);
+int symlink(char *path1, char *path2);
 int _getcwd(char* buf, int size);
 char* getcwd(char* buf, unsigned size);
 char* getwd(char* buf);

--- a/x86/linux/unistd.c
+++ b/x86/linux/unistd.c
@@ -136,7 +136,7 @@ int unlink (char *filename)
 	    "int !0x80");
 }
 
-int symlink(const char *path1, const char *path2)
+int symlink(char *path1, char *path2)
 {
 	asm("lea_ebx,[esp+DWORD] %8"
 	    "mov_ebx,[ebx]"


### PR DESCRIPTION
This change removes the "const" specifier for the "symlink()" syscall wrappers, due to an incompatibility with M2-Planet.