### PR TITLE
Fix mis-merged error in unlink wrapper on Linux/aarch64

### DIFF
--- a/aarch64/linux/unistd.c
+++ b/aarch64/linux/unistd.c
@@ -144,6 +144,7 @@ int unlink (char* filename)
 	    "SET_X2_TO_0"
 	    "SET_X0_TO_FCNTL_H_AT_FDCWD"
 	    "SET_X8_TO_SYS_UNLINKAT"
+	    "SYSCALL");
 }
 
 int symlink(char *path1, char *path2)


### PR DESCRIPTION
This change fixes an error when merging in #17 as part of #65.