### PR TITLE
Add stdbool.h header

### DIFF
--- a/stdbool.h
+++ b/stdbool.h
@@ -1,0 +1,29 @@
+/* Copyright (C) 2024 Jeremiah Orians
+ * This file is part of M2-Planet.
+ *
+ * M2-Planet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * M2-Planet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with M2-Planet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _STDBOOL_H
+#define _STDBOOL_H
+
+#define __bool_true_false_are_defined 1
+
+/* Not standard compliant but we don't have the _Bool type */
+#define bool char
+
+#define true 1
+#define false 0
+
+#endif

--- a/stdbool.h
+++ b/stdbool.h
@@ -20,8 +20,7 @@
 
 #define __bool_true_false_are_defined 1
 
-/* Not standard compliant but we don't have the _Bool type */
-#define bool char
+#define bool _Bool
 
 #define true 1
 #define false 0


### PR DESCRIPTION
`bool` could also be an `int` but all the major compilers have sizeof(bool) == 1.

The standard (C17) says in 6.2.5.2:
```text
An object declared as type _Bool is large enough to store the values 0 and 1
```

`_Bool` could also have been defined, although I don't think that's standards conforming it has to be a compiler handled type.