### PR TITLE
Remove incorrect pointer arithmetic from setenv/getenv

### DIFF
--- a/stdlib.c
+++ b/stdlib.c
@@ -438,7 +438,7 @@ char* getenv (char const* name)
 			if(q[0] == '=')
 				return q + 1;
 		}
-		p += sizeof(char**); /* M2 pointer arithemtic */
+		p += 1;
 	}
 
 	return 0;
@@ -475,7 +475,7 @@ int setenv(char const *s, char const *v, int overwrite_p)
 			if (q[0] == '=')
 				break;
 		}
-		p += sizeof(char**); /* M2 pointer arithemtic */
+		p += 1;
 	}
 	char *entry = malloc (length + _strlen(v) + 2);
 	int end_p = p[0] == 0;


### PR DESCRIPTION
This will been fixed in M2-Planet in https://github.com/oriansj/M2-Planet/issues/66 although I'm not entirely sure which order it should be fixed in or if this needs to be ifdeffed in case other compilers without correct pointer arithmetic also use `M2libc`.