### PR TITLE
Add amd64 mov_rbx,rax instruction

### DIFF
--- a/amd64/amd64_defs.M1
+++ b/amd64/amd64_defs.M1
@@ -58,6 +58,7 @@ DEFINE mov_rax,rdx 4889D0
 DEFINE mov_rax,rbx 4889D8
 DEFINE mov_rax,rbp 4889E8
 DEFINE mov_rax,rsp 4889E0
+DEFINE mov_rbx,rax 4889C3
 DEFINE mov_rbx,rdi 4889FB
 DEFINE mov_rbp,rdi 4889FD
 DEFINE mov_rbp,rsp 4889E5


### PR DESCRIPTION
This is useful for better codegen in M2-Planet at https://github.com/oriansj/M2-Planet/blob/664cf10452068e6280fae78990f082bdbfe20dd1/cc_core.c#L2562.

Verify with `echo "main: mov     rbx, rax" > main.s && nasm -f elf64 main.s && objdump -d main.o`:

```text
main.o:     file format elf64-x86-64


Disassembly of section .text:

0000000000000000 <main>:
   0:   48 89 c3                mov    %rax,%rbx
```

@stikonas @oriansj 