### PR TITLE
Add xor_reg,reg for zeroing out registers for amd64/x86

### DIFF
--- a/amd64/amd64_defs.M1
+++ b/amd64/amd64_defs.M1
@@ -165,3 +165,9 @@ DEFINE test_rax,rax 4885C0
 DEFINE wrmsr 0F30
 DEFINE xchg_rbx,rax 4893
 DEFINE xor_rax,rbx 4831D8
+DEFINE xor_eax,eax 31C0
+DEFINE xor_ebx,ebx 31DB
+DEFINE xor_ecx,ecx 31C9
+DEFINE xor_edx,edx 31D2
+DEFINE xor_edi,edi 31FF
+DEFINE xor_esi,esi 31F6

--- a/x86/x86_defs.M1
+++ b/x86/x86_defs.M1
@@ -100,3 +100,9 @@ DEFINE sub_ebx,eax 29C3
 DEFINE test_eax,eax 85C0
 DEFINE xchg_ebx,eax 93
 DEFINE xor_eax,ebx 31D8
+DEFINE xor_eax,eax 31C0
+DEFINE xor_ebx,ebx 31DB
+DEFINE xor_ecx,ecx 31C9
+DEFINE xor_edx,edx 31D2
+DEFINE xor_edi,edi 31FF
+DEFINE xor_esi,esi 31F6


### PR DESCRIPTION
This is the recommended way of zeroing out a register, even for amd64 since zeroing the lower 32 bits automatically also zeros out the upper 32 bits.

I didn't bother with the stack pointer and base pointer registers since we probably don't need to zero those.

@stikonas @oriansj 

```asm
main:
    xor eax, eax
    xor ebx, ebx
    xor ecx, ecx
    xor edx, edx
    xor edi, edi
    xor esi, esi
```

```sh
nasm -f elf32 main.s && objdump -d main.o
```

leads to

```text
main.o:     file format elf32-i386

Disassembly of section .text:

00000000 <main>:
   0:   31 c0                   xor    %eax,%eax
   2:   31 db                   xor    %ebx,%ebx
   4:   31 c9                   xor    %ecx,%ecx
   6:   31 d2                   xor    %edx,%edx
   8:   31 ff                   xor    %edi,%edi
   a:   31 f6                   xor    %esi,%esi
```