### PR TITLE
Add sub_rax,rbx for x86/amd64

### DIFF
--- a/amd64/amd64_defs.M1
+++ b/amd64/amd64_defs.M1
@@ -159,6 +159,7 @@ DEFINE setl_al 0F9CC0
 DEFINE setle_al 0F9EC0
 DEFINE setne_al 0F95C0
 DEFINE sub_rsp, 4881EC
+DEFINE sub_rax,rbx 4829D8
 DEFINE sub_rbx,rax 4829C3
 DEFINE syscall 0F05
 DEFINE test_rax,rax 4885C0

--- a/x86/x86_defs.M1
+++ b/x86/x86_defs.M1
@@ -96,6 +96,7 @@ DEFINE setl_al 0F9CC0
 DEFINE setge_al 0F9DC0
 DEFINE setg_al 0F9FC0
 DEFINE setne_al 0F95C0
+DEFINE sub_eax,ebx 29D8
 DEFINE sub_ebx,eax 29C3
 DEFINE test_eax,eax 85C0
 DEFINE xchg_ebx,eax 93


### PR DESCRIPTION
@stikonas @oriansj 

These already exist for the others but were emulated on x86/amd64 with a mov afterwards.

```bash
printf "_start: sub rax, rbx\nsub eax, ebx" > main.s && nasm -f elf64 main.s && objdump -M intel -d main.o

main.o:     file format elf64-x86-64

Disassembly of section .text:

0000000000000000 <_start>:
   0:	48 29 d8             	sub    rax,rbx
   3:	29 d8                	sub    eax,ebx

```