### PR TITLE
Add knight defines to unistd.h/stat.h

### DIFF
--- a/sys/stat.h
+++ b/sys/stat.h
@@ -33,6 +33,10 @@
 #include <riscv32/linux/sys/stat.c>
 #elif __riscv && __riscv_xlen==64
 #include <riscv64/linux/sys/stat.c>
+#elif __knight_posix__
+#include <knight/linux/sys/stat.c>
+#elif __knight__
+#include <knight/native/sys/stat.c>
 #else
 #error arch not supported
 #endif

--- a/unistd.h
+++ b/unistd.h
@@ -33,6 +33,10 @@
 #include <riscv32/linux/unistd.c>
 #elif __riscv && __riscv_xlen==64
 #include <riscv64/linux/unistd.c>
+#elif __knight_posix__
+#include <knight/linux/unistd.c>
+#elif __knight__
+#include <knight/native/unistd.c>
 #else
 #error arch not supported
 #endif


### PR DESCRIPTION
With functional include support in M2-Planet including `sys/stat.h` or `unistd.h` fails for Knight because of this.

@stikonas @oriansj 