### PR TITLE
Fix UEFI writes acting strange after M2-Planet changes

### DIFF
--- a/uefi/unistd.c
+++ b/uefi/unistd.c
@@ -223,7 +223,12 @@ int write(int fd, char* buf, unsigned count)
 {
 	struct efi_file_protocol* f = fd;
 	unsigned i;
-	char c = 0;
+	/* UEFI requires UTF-16 chars with a 2 byte null terminator.
+	 * We only write a single char at a time which requires 4 bytes.
+	 * 2 for the char itself and 2 for the null terminator.
+	 * With an int64_t we are guaranteed that the null terminator
+	 * is present, initialized at declaration, and aligned correctly.*/
+	int64_t c = 0;
 
 	/* In UEFI StdErr might not be printing stuff to console, so just use stdout */
 	if(f == STDOUT_FILENO || f == STDERR_FILENO)


### PR DESCRIPTION
@stikonas @oriansj 

[oriansj/M2-Planet@`413c69f` (#120)](https://github.com/oriansj/M2-Planet/pull/120/commits/413c69f4a58ff3e294572549875195df9ccfb5a8) introduced a regression for UEFI where output was not working correctly.

This is because UEFI uses UTF-16 for strings and in the commit we allocated stack space by pushes which zeros the upper bytes while store_value did not. The UTF-16 string required 3 byte of zeroes after the initial character value. Because we only wrote to the lower part of the register the top parts were effectively uninitialized.