### PR TITLE
amd64: Add optimized read function

### DIFF
--- a/amd64/linux/bootstrap.c
+++ b/amd64/linux/bootstrap.c
@@ -55,21 +55,19 @@ unsigned read(FILE* f, char* buffer, unsigned count) {
 }
 
 
+char* __fputc_buffer;
 int fgetc(FILE* f)
 {
-	asm("lea_rdi,[rsp+DWORD] %8"
-	    "mov_rdi,[rdi]"
-	    "mov_rax, %0"
-	    "push_rax"
-	    "lea_rsi,[rsp+DWORD] %0"
-	    "mov_rdx, %1"
-	    "syscall"
-	    "mov_rbx, %0"
-	    "cmp_rbx,rax"
-	    "pop_rax"
-	    "jne %FUNCTION_fgetc_Done"
-	    "mov_rax, %-1"
-	    ":FUNCTION_fgetc_Done");
+	/* We don't have operator & */
+	if(__fputc_buffer == NULL) {
+		__fputc_buffer = malloc(1);
+	}
+
+	if(read(f, __fputc_buffer, 1) == 1) {
+		return EOF;
+	}
+
+	return __fputc_buffer[0];
 }
 
 unsigned fread(char* buffer, unsigned size, unsigned count, FILE* f) {
@@ -89,7 +87,6 @@ unsigned write(FILE* f, char* buffer, unsigned count) {
 			"syscall");
 }
 
-char* __fputc_buffer;
 void fputc(char s, FILE* f)
 {
 	/* We don't have operator & */

--- a/amd64/linux/bootstrap.c
+++ b/amd64/linux/bootstrap.c
@@ -42,6 +42,19 @@ enum
 
 void* malloc(int size);
 
+unsigned read(FILE* f, char* buffer, unsigned count) {
+	asm(
+			"xor_eax,eax"
+			"lea_rsi,[rsp+DWORD] %16"
+			"mov_rsi,[rsi]"
+			"lea_rdx,[rsp+DWORD] %8"
+			"mov_rdx,[rdx]"
+			"lea_rdi,[rsp+DWORD] %24"
+			"mov_rdi,[rdi]"
+			"syscall");
+}
+
+
 int fgetc(FILE* f)
 {
 	asm("lea_rdi,[rsp+DWORD] %8"
@@ -60,15 +73,9 @@ int fgetc(FILE* f)
 }
 
 unsigned fread(char* buffer, unsigned size, unsigned count, FILE* f) {
-	count = size * count;
-
-	unsigned i = 0;
-	for(; i < count; i = i + 1) {
-		buffer[i] = fgetc(f);
-	}
-
-	return i;
+	return read(f, buffer, size * count);
 }
+
 
 unsigned write(FILE* f, char* buffer, unsigned count) {
 	asm(


### PR DESCRIPTION
For my assembler on WSL this impressively reduces a single test execution time from ~50 seconds to < 3 seconds using a simple buffer rather than repeatedly calling `fgetc` like we do in M2-Planet.

Perhaps this might also be worthwhile for very slow systems like RISC-V? I'm not sure if the syscall overhead dominates as much or if it's just generally slow.

@stikonas @oriansj 