### PR TITLE
amd64: Fix fgetc checking incorrect return value

### DIFF
--- a/amd64/linux/bootstrap.c
+++ b/amd64/linux/bootstrap.c
@@ -63,7 +63,7 @@ int fgetc(FILE* f)
 		__fputc_buffer = malloc(1);
 	}
 
-	if(read(f, __fputc_buffer, 1) == 1) {
+	if(read(f, __fputc_buffer, 1) <= 0) {
 		return EOF;
 	}
 

--- a/amd64/linux/bootstrap.c
+++ b/amd64/linux/bootstrap.c
@@ -44,7 +44,7 @@ void* malloc(int size);
 
 unsigned read(FILE* f, char* buffer, unsigned count) {
 	asm(
-			"xor_eax,eax"
+			"mov_rax, %0"
 			"lea_rsi,[rsp+DWORD] %16"
 			"mov_rsi,[rsi]"
 			"lea_rdx,[rsp+DWORD] %8"


### PR DESCRIPTION
I have no idea how this worked. Tests for M2-Planet pass with it but stage0-posix does not.

The newer xor_eax,eax define isn't present in the bootstrap defines for stage0-posix. It's also easier to read for people who are less into x86 assembly so I just changed it rather than add the define.

@stikonas @oriansj 