### PR TITLE
Fix off-by-one in strdup: allocate space for null terminator

### DIFF
--- a/string.c
+++ b/string.c
@@ -285,7 +285,7 @@ char* strdup(const char* s)
 {
 	size_t length = strlen(s);
 
-	char* new_string = malloc(length);
+	char* new_string = malloc(length + 1);
 
 	if(!new_string)
 	{


### PR DESCRIPTION
strdup allocated strlen(s) bytes but copied strlen(s)+1, writing one byte past the allocation.