### PR TITLE
amd64/x86: Add `mov_rbx,rsp`/`mov_ebx,esp`

### DIFF
--- a/amd64/amd64_defs.M1
+++ b/amd64/amd64_defs.M1
@@ -128,6 +128,7 @@ DEFINE mov_rax,r14 4C89F0
 DEFINE mov_rax,r15 4C89F8
 DEFINE mov_rbx,rax 4889C3
 DEFINE mov_rbx,rcx 4889CB
+DEFINE mov_rbx,rsp 4889E3
 DEFINE mov_rbx,rdi 4889FB
 DEFINE mov_rbx,r10 4C89D3
 DEFINE mov_rbx,r11 4C89DB

--- a/x86/x86_defs.M1
+++ b/x86/x86_defs.M1
@@ -102,6 +102,7 @@ DEFINE mov_edx,ebx 89DA
 DEFINE mov_ebx,eax 89C3
 DEFINE mov_ebx,ecx 89CB
 DEFINE mov_ebx,edx 89D3
+DEFINE mov_ebx,esp 89E3
 DEFINE mov_ebx,edi 89FB
 DEFINE mov_ecx,eax 89C1
 DEFINE mov_ecx,ebx 89D9


### PR DESCRIPTION
@stikonas @oriansj 