### PR TITLE
Fix libc edge-case correctness bugs

### DIFF
--- a/amd64/uefi/bootstrap.c
+++ b/amd64/uefi/bootstrap.c
@@ -557,6 +557,7 @@ void* memset(void* ptr, int value, int num)
 		s[0] = value;
 		s = s + 1;
 	}
+	return ptr;
 }
 
 void* calloc(int count, int size)

--- a/bootstrap.c
+++ b/bootstrap.c
@@ -125,7 +125,7 @@ void* malloc(int size)
 	{
 		long old_brk = _brk_ptr;
 		_brk_ptr = brk(_malloc_ptr + size);
-		if(-4 /* EINTR */ == _brk_ptr || _brk_ptr == old_brk || old_brk + size < _brk_ptr) return 0;
+		if(-4 /* EINTR */ == _brk_ptr || _brk_ptr == old_brk || _brk_ptr < _malloc_ptr + size) return 0;
 	}
 
 	long old_malloc = _malloc_ptr;
@@ -153,6 +153,7 @@ void* memset(void* ptr, int value, int num)
 		s[0] = value;
 		s = s + 1;
 	}
+	return ptr;
 }
 
 /* The real memcpy has void* parameters and return types, but
@@ -193,7 +194,6 @@ char* strchr(char* str, int ch)
 		if(0 == p[0]) return NULL;
 		p = p + 1;
 	}
-	if(0 == p[0]) return NULL;
 	return p;
 }
 
@@ -224,6 +224,7 @@ int atoi(char* str)
 	int negative = 0;
 	if (str[0] == '-') {
 		negative = 1;
+		str = str + 1;
 	}
 	if (str[0] == '+') {
 		str = str + 1;
@@ -272,4 +273,3 @@ int abs(int n) {
     }
     return n;
 }
-

--- a/knight/native/bootstrap.c
+++ b/knight/native/bootstrap.c
@@ -183,6 +183,7 @@ void* memset(void* ptr, int value, int num)
 		s[0] = value;
 		s = s + 1;
 	}
+	return ptr;
 }
 
 void* calloc(int count, int size)

--- a/knight/native/unistd.c
+++ b/knight/native/unistd.c
@@ -97,6 +97,7 @@ int write(int fd, char* buf, unsigned count)
 		__write(buf[i], fd);
 		i = i + 1;
 	}
+	return i;
 }
 
 int lseek(int fd, int offset, int whence)

--- a/stdio.c
+++ b/stdio.c
@@ -109,7 +109,7 @@ size_t fread( void* buffer, size_t size, size_t count, FILE* stream )
 	if(0 == size) return 0;
 	if(0 == count) return 0;
 
-	long n = size + count - 1;
+	long n = size * count;
 	char* p = buffer;
 	long i;
 	unsigned c;
@@ -133,7 +133,8 @@ char* fgets(char* str, int count, FILE* stream)
 {
 	int i = 0;
 	int ch;
-	while(i < count)
+	if(count <= 0) return NULL;
+	while(i < count - 1)
 	{
 		ch = fgetc(stream);
 		if(EOF == ch) {
@@ -148,6 +149,7 @@ char* fgets(char* str, int count, FILE* stream)
 		if('\n' == ch) break;
 	}
 
+	str[i] = 0;
 	return str;
 }
 
@@ -209,14 +211,11 @@ int puts(char const* str)
 
 
 int lseek(int fd, int offset, int whence);
+int close(int fd);
 /* File management */
 FILE* fopen(char const* filename, char const* mode)
 {
 	int f;
-	FILE* fi = calloc(1, sizeof(FILE));
-	fi->next = __list;
-	if(NULL != __list) __list->prev = fi;
-	__list = fi;
 	int size;
 
 	if('w' == mode[0]) f = open(filename, O_WRONLY|O_CREAT|O_TRUNC, 00600);
@@ -229,10 +228,23 @@ FILE* fopen(char const* filename, char const* mode)
 		return 0;
 	}
 
+	FILE* fi = calloc(1, sizeof(FILE));
+	if(NULL == fi)
+	{
+		close(f);
+		return 0;
+	}
+
 	if('w' == mode[0] || 'a' == mode[0])
 	{
 		/* Buffer as much as possible */
 		fi->buffer = malloc(BUFSIZ * sizeof(char));
+		if(NULL == fi->buffer)
+		{
+			close(f);
+			free(fi);
+			return 0;
+		}
 		fi->buflen = BUFSIZ;
 		fi->bufmode = O_WRONLY;
 	}
@@ -240,7 +252,19 @@ FILE* fopen(char const* filename, char const* mode)
 	{
 		/* Get enough buffer to read it all */
 		size = lseek(f, 0, SEEK_END);
+		if(size < 0)
+		{
+			close(f);
+			free(fi);
+			return 0;
+		}
 		fi->buffer = malloc((size + 1) * sizeof(char));
+		if(NULL == fi->buffer)
+		{
+			close(f);
+			free(fi);
+			return 0;
+		}
 		fi->buflen = size;
 		fi->bufmode = O_RDONLY;
 
@@ -249,6 +273,9 @@ FILE* fopen(char const* filename, char const* mode)
 		read(f, fi->buffer, size);
 	}
 
+	fi->next = __list;
+	if(NULL != __list) __list->prev = fi;
+	__list = fi;
 	fi->fd = f;
 	return fi;
 }
@@ -256,15 +283,18 @@ FILE* fopen(char const* filename, char const* mode)
 FILE* fdopen(int fd, char* mode)
 {
 	FILE* fi = calloc(1, sizeof(FILE));
-	fi->next = __list;
-	if(NULL != __list) __list->prev = fi;
-	__list = fi;
+	if(NULL == fi) return 0;
 	int size;
 
 	if('w' == mode[0])
 	{
 		/* Buffer as much as possible */
 		fi->buffer = malloc(BUFSIZ * sizeof(char));
+		if(NULL == fi->buffer)
+		{
+			free(fi);
+			return 0;
+		}
 		fi->buflen = BUFSIZ;
 		fi->bufmode = O_WRONLY;
 	}
@@ -272,7 +302,17 @@ FILE* fdopen(int fd, char* mode)
 	{
 		/* Get enough buffer to read it all */
 		size = lseek(fd, 0, SEEK_END);
+		if(size < 0)
+		{
+			free(fi);
+			return 0;
+		}
 		fi->buffer = malloc((size + 1) * sizeof(char));
+		if(NULL == fi->buffer)
+		{
+			free(fi);
+			return 0;
+		}
 		fi->buflen = size;
 		fi->bufmode = O_RDONLY;
 
@@ -281,6 +321,9 @@ FILE* fdopen(int fd, char* mode)
 		read(fd, fi->buffer, size);
 	}
 
+	fi->next = __list;
+	if(NULL != __list) __list->prev = fi;
+	__list = fi;
 	fi->fd = fd;
 	return fi;
 }
@@ -306,7 +349,6 @@ int fflush(FILE* stream)
 }
 
 
-int close(int fd);
 int fclose(FILE* stream)
 {
 	/* Deal with STDIN, STDOUT and STDERR */
@@ -471,7 +513,7 @@ char* __integer_to_string(int value)
 int __vsnprintf_string_offset;
 va_list __vsnprintf_ap;
 /* One line since M2-Mesoplanet doesn't support multi line macros */
-#define INLINE_STRSCPY str_i = 0; while(str[str_i] != '\0' && output < n) { s[output++] = str[str_i++]; }
+#define INLINE_STRSCPY str_i = 0; while(str[str_i] != '\0' && output < n - 1) { s[output++] = str[str_i++]; }
 int vsnprintf(char* s, size_t n, const char* format, va_list arg)
 {
 	int i = 0;
@@ -481,7 +523,8 @@ int vsnprintf(char* s, size_t n, const char* format, va_list arg)
 
 	__vsnprintf_string_offset = 0;
 
-	while(format[i] != '\0' && output < n)
+	if(0 == n) return 0;
+	while(format[i] != '\0' && output < n - 1)
 	{
 		if(format[i] == '%')
 		{
@@ -519,7 +562,7 @@ int vsnprintf(char* s, size_t n, const char* format, va_list arg)
 				int value = va_arg(arg, int);
 				if(value < 0)
 				{
-					s[output++] = '-';
+					if(output < n - 1) s[output++] = '-';
 					value = -value;
 				}
 				str = __integer_to_string(value);
@@ -528,18 +571,19 @@ int vsnprintf(char* s, size_t n, const char* format, va_list arg)
 			else if(format[i] == 'c')
 			{
 				char value = va_arg(arg, char);
-				s[output++] = value;
+				if(output < n - 1) s[output++] = value;
 			}
 			else if(format[i] == '%')
 			{
-					s[output++] = '%';
+				if(output < n - 1) s[output++] = '%';
 			}
 
 			++i;
 		}
 		else
 		{
-			s[output++] = format[i++];
+			if(output < n - 1) s[output++] = format[i];
+			i = i + 1;
 		}
 	}
 

--- a/stdlib.c
+++ b/stdlib.c
@@ -56,8 +56,11 @@ void* _malloc_brk(unsigned size)
 
 	if(_brk_ptr < _malloc_ptr + size)
 	{
+		long old_brk = _brk_ptr;
 		_brk_ptr = brk(_malloc_ptr + size);
 		if(-1 == _brk_ptr) return 0;
+		if(_brk_ptr == old_brk) return 0;
+		if(_brk_ptr < _malloc_ptr + size) return 0;
 	}
 
 	long old_malloc = _malloc_ptr;
@@ -177,7 +180,7 @@ void* _malloc_find_free(unsigned size)
 	while(NULL != i)
 	{
 		/* see if anything in it is equal or bigger than what I need */
-		if((_NOT_IN_USE == i->used) && (i->size > size))
+		if((_NOT_IN_USE == i->used) && (i->size >= size))
 		{
 			/* disconnect from list ensuring we don't break free doing so */
 			if(NULL == last) _free_list = i->next;
@@ -288,6 +291,12 @@ void* malloc(unsigned size)
 
 void* realloc(void* ptr, unsigned size)
 {
+	if(0 == size)
+	{
+		if(NULL != ptr) free(ptr);
+		return NULL;
+	}
+
 	void* new_alloc = malloc(size);
 
 	if(ptr == NULL || new_alloc == NULL)
@@ -298,6 +307,7 @@ void* realloc(void* ptr, unsigned size)
 	}
 
 	size_t old_alloc_size = 0;
+	size_t copy_size;
 	struct _malloc_node* i = _allocated_list;
 	while(NULL != i)
 	{
@@ -318,11 +328,13 @@ void* realloc(void* ptr, unsigned size)
 		exit(EXIT_FAILURE);
 	}
 
-	/* memcpy(new_alloc, ptr, old_alloc_size); */
+	copy_size = old_alloc_size;
+	if(size < copy_size) copy_size = size;
+	/* memcpy(new_alloc, ptr, copy_size); */
 	int i;
 	char* new_alloc_char = (char*)new_alloc;
 	char* ptr_char = (char*)ptr;
-	for (i = 0; i < old_alloc_size; ++i)
+	for (i = 0; i < copy_size; ++i)
 	{
 		new_alloc_char[i] = ptr_char[i];
 	}
@@ -513,6 +525,7 @@ int setenv(char const *s, char const *v, int overwrite_p)
 {
 	char** p = _envp;
 	int length = _strlen(s);
+	int value_length = _strlen(v);
 	char* q;
 
 	while (p[0] != 0)
@@ -521,17 +534,21 @@ int setenv(char const *s, char const *v, int overwrite_p)
 		{
 			q = p[0] + length;
 			if (q[0] == '=')
+			{
+				if(0 == overwrite_p) return 0;
 				break;
+			}
 		}
 		p += 1;
 	}
-	char *entry = malloc (length + _strlen(v) + 2);
+	char *entry = malloc (length + value_length + 2);
+	if(NULL == entry) return -1;
 	int end_p = p[0] == 0;
 	p[0] = entry;
 	_strcpy(entry, s);
 	_strcpy(entry + length, "=");
 	_strcpy(entry + length + 1, v);
-	entry[length + _strlen(v) + 2] = 0;
+	entry[length + value_length + 1] = 0;
 	if (end_p != 0)
 		p[1] = 0;
 
@@ -573,4 +590,3 @@ int atoi(const char* str)
 		return -value;
 	}
 }
-

--- a/string.c
+++ b/string.c
@@ -44,7 +44,7 @@ char* strncpy(char* dest, char const* src, size_t count)
 		if(count == i) return dest;
 	}
 
-	while(i <= count)
+	while(i < count)
 	{
 		dest[i] = 0;
 		i = i + 1;
@@ -101,10 +101,11 @@ size_t strlen(char const* str )
 
 size_t strnlen_s(char const* str, size_t strsz )
 {
+	if(NULL == str) return 0;
 	size_t i = 0;
-	while(0 != str[i])
+	while(i < strsz)
 	{
-		if(strsz == i) return i;
+		if(0 == str[i]) return i;
 		i = i + 1;
 	}
 	return i;
@@ -148,7 +149,6 @@ char* strchr(char const* str, int ch)
 		if(0 == p[0]) return NULL;
 		p = p + 1;
 	}
-	if(0 == p[0]) return NULL;
 	return p;
 }
 
@@ -191,10 +191,10 @@ char* strpbrk(char const* dest, char const* breakset)
 	while(0 != p[0])
 	{
 		s = strchr(breakset, p[0]);
-		if(NULL != s) return strchr(p,  s[0]);
+		if(NULL != s) return p;
 		p = p + 1;
 	}
-	return p;
+	return NULL;
 }
 
 
@@ -230,14 +230,14 @@ void* memcpy(void* dest, void const* src, size_t count)
 
 void* memmove(void* dest, void const* src, size_t count)
 {
+	if(0 == count) return dest;
 	if (dest < src) return memcpy (dest, src, count);
 	char *p = dest;
 	char const *q = src;
-	count = count - 1;
-	while (count >= 0)
+	while (0 < count)
 	{
-		p[count] = q[count];
 		count = count - 1;
+		p[count] = q[count];
 	}
 	return dest;
 }
@@ -295,4 +295,3 @@ char* strdup(const char* s)
 	/* strlen does not include the null terminator */
 	return memcpy(new_string, s, length + 1);
 }
-

--- a/uefi/string_p.h
+++ b/uefi/string_p.h
@@ -43,7 +43,7 @@ char* strncpy(char* dest, char const* src, size_t count)
 		if(count == i) return dest;
 	}
 
-	while(i <= count)
+	while(i < count)
 	{
 		dest[i] = 0;
 		i = i + 1;
@@ -100,10 +100,11 @@ size_t strlen(char const* str )
 
 size_t strnlen_s(char const* str, size_t strsz )
 {
+	if(NULL == str) return 0;
 	size_t i = 0;
-	while(0 != str[i])
+	while(i < strsz)
 	{
-		if(strsz == i) return i;
+		if(0 == str[i]) return i;
 		i = i + 1;
 	}
 	return i;
@@ -145,7 +146,6 @@ char* strchr(char const* str, int ch)
 		if(0 == p[0]) return NULL;
 		p = p + 1;
 	}
-	if(0 == p[0]) return NULL;
 	return p;
 }
 
@@ -188,10 +188,10 @@ char* strpbrk(char const* dest, char const* breakset)
 	while(0 != p[0])
 	{
 		s = strchr(breakset, p[0]);
-		if(NULL != s) return strchr(p,  s[0]);
+		if(NULL != s) return p;
 		p = p + 1;
 	}
-	return p;
+	return NULL;
 }
 
 
@@ -227,14 +227,14 @@ void* memcpy(void* dest, void const* src, size_t count)
 
 void* memmove(void* dest, void const* src, size_t count)
 {
+	if(0 == count) return dest;
 	if (dest < src) return memcpy (dest, src, count);
 	char *p = dest;
 	char const *q = src;
-	count = count - 1;
-	while (count >= 0)
+	while (0 < count)
 	{
-		p[count] = q[count];
 		count = count - 1;
+		p[count] = q[count];
 	}
 	return dest;
 }


### PR DESCRIPTION
Fix several libc edge cases that can write past caller buffers, copy past a shrunk allocation, leave unterminated strings, or continue after failed stream allocation.

The most important fixes cover `fgets`, `vsnprintf`, `strncpy`, `strnlen_s`, `memmove`, `realloc`, `setenv`, `fread`, and failed `fopen`/`fdopen` setup. Reduced versions of the old code were validated with GCC AddressSanitizer/UBSan, which reproduced the buffer overflows, NULL write, and missing-return issues.
