### PR TITLE
Buffer stdio reads lazily

### DIFF
--- a/stdio.c
+++ b/stdio.c
@@ -90,7 +90,19 @@ int fgetc(FILE* f)
 		int r = read(f->fd, f->buffer, 1);
 
 		/* Catch special case of STDIN gets nothing (AN EOF) */
-		if(0 == r) return EOF;
+		if(0 >= r) return EOF;
+	}
+	else if(f->buflen <= f->bufpos)
+	{
+		f->file_pos = f->file_pos + f->buflen;
+		f->bufpos = 0;
+		f->buflen = read(f->fd, f->buffer, BUFSIZ);
+
+		if(0 >= f->buflen)
+		{
+			f->buflen = 0;
+			return EOF;
+		}
 	}
 
 	/* Catch EOF */
@@ -216,7 +228,6 @@ int close(int fd);
 FILE* fopen(char const* filename, char const* mode)
 {
 	int f;
-	int size;
 
 	if('w' == mode[0]) f = open(filename, O_WRONLY|O_CREAT|O_TRUNC, 00600);
 	else if('a' == mode[0]) f = open(filename, O_WRONLY|O_CREAT|O_APPEND, 00600);
@@ -250,27 +261,15 @@ FILE* fopen(char const* filename, char const* mode)
 	}
 	else
 	{
-		/* Get enough buffer to read it all */
-		size = lseek(f, 0, SEEK_END);
-		if(size < 0)
-		{
-			close(f);
-			free(fi);
-			return 0;
-		}
-		fi->buffer = malloc((size + 1) * sizeof(char));
+		fi->buffer = malloc(BUFSIZ * sizeof(char));
 		if(NULL == fi->buffer)
 		{
 			close(f);
 			free(fi);
 			return 0;
 		}
-		fi->buflen = size;
+		fi->buflen = 0;
 		fi->bufmode = O_RDONLY;
-
-		/* Now read it all */
-		lseek(f, 0, SEEK_SET);
-		read(f, fi->buffer, size);
 	}
 
 	fi->next = __list;
@@ -284,7 +283,6 @@ FILE* fdopen(int fd, char* mode)
 {
 	FILE* fi = calloc(1, sizeof(FILE));
 	if(NULL == fi) return 0;
-	int size;
 
 	if('w' == mode[0])
 	{
@@ -300,25 +298,14 @@ FILE* fdopen(int fd, char* mode)
 	}
 	else
 	{
-		/* Get enough buffer to read it all */
-		size = lseek(fd, 0, SEEK_END);
-		if(size < 0)
-		{
-			free(fi);
-			return 0;
-		}
-		fi->buffer = malloc((size + 1) * sizeof(char));
+		fi->buffer = malloc(BUFSIZ * sizeof(char));
 		if(NULL == fi->buffer)
 		{
 			free(fi);
 			return 0;
 		}
-		fi->buflen = size;
+		fi->buflen = 0;
 		fi->bufmode = O_RDONLY;
-
-		/* Now read it all */
-		lseek(fd, 0, SEEK_SET);
-		read(fd, fi->buffer, size);
 	}
 
 	fi->next = __list;
@@ -419,7 +406,7 @@ long ftell(FILE* stream)
 	if(O_WRONLY == stream->bufmode) return stream->file_pos + stream->bufpos;
 
 	/* Deal with read */
-	return stream->bufpos;
+	return stream->file_pos + stream->bufpos;
 }
 
 
@@ -438,6 +425,7 @@ int fseek(FILE* f, long offset, int whence)
 
 	/* Deal with read mode */
 	int pos;
+	int end;
 
 	if(SEEK_SET == whence)
 	{
@@ -445,18 +433,22 @@ int fseek(FILE* f, long offset, int whence)
 	}
 	else if(SEEK_CUR == whence)
 	{
-		pos = f->bufpos + offset;
+		pos = ftell(f) + offset;
 	}
 	else if(SEEK_END == whence)
 	{
-		pos = f->buflen + offset;
+		end = lseek(f->fd, 0, SEEK_END);
+		if(end < 0) return -1;
+		pos = end + offset;
 	}
 	else return -1;
 
 	if(pos < 0) return -1;
-	if(pos > f->buflen) return -1;
 
-	f->bufpos = pos;
+	if(0 > lseek(f->fd, pos, SEEK_SET)) return -1;
+	f->file_pos = pos;
+	f->bufpos = 0;
+	f->buflen = 0;
 	return pos;
 }
 


### PR DESCRIPTION
This changes read-mode stdio streams to allocate a fixed `BUFSIZ` buffer and refill it from `fgetc` instead of sizing the buffer to the whole file and reading the entire input in `fopen`/`fdopen`.

That avoids an O(file size) allocation/read during open and lets larger inputs stream normally. `ftell` and read-mode `fseek` now account for the buffered file position, and the stdin read path now treats negative read results like EOF instead of reusing stale buffer contents.

Validation:
- `git diff --check`
- M2-Planet smoke compile with this checkout on the include path: `M2-Planet --expand-includes -D __M2__=1 --architecture x86 ...`
- M2 -> M1 -> hex2 x86 link for a stdio smoke binary
- Runtime smoke test for `fgetc`, `fseek`, and `ftell`
- Runtime boundary test reading past `BUFSIZ` and seeking around offset 4096

Benchmark:
- Built old and new x86 benchmark binaries with M2-Planet, then assembled/linked them with M1 and hex2.
- Test case: `fopen` a 256 MiB regular file, read one byte with `fgetc`, close, and exit.
- Old/current `main`: 0.15-0.20s elapsed, about 260-261 MiB max RSS.
- This branch: 0.00s elapsed at this timer resolution, 256 KiB max RSS.
- Direct `/proc/$pid/status` sampling after `fopen`/`fgetc` in a hold-loop binary: old about 262 MiB RSS, new about 48 KiB RSS.

Context: this came out of the mescc-tools PR 58 follow-up audit. The earlier malloc exact-fit and strstr length issues I noticed are already fixed on current `main`, so this PR is limited to the remaining stdio buffering issue.
